### PR TITLE
Add stochastic process simulator with plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
-# Stochastic-Prossesses
-Calculator/plotter of stochastic processes
+# Stochastic Processes Simulator
+
+A small command-line tool for simulating and visualising common discrete-time
+and continuous-time stochastic processes. The simulator can generate one or
+multiple sample paths, display them using Matplotlib and/or save the output as
+an image.
+
+## Getting started
+
+Install the Python dependencies (Python 3.10+ is recommended):
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+List the available processes:
+
+```bash
+python simulate.py --list
+```
+
+Simulate a process by providing its identifier and any optional parameters. All
+process-specific options can be inspected via `--help` after the process name.
+For example, to simulate a random walk with 300 steps and save the resulting
+plot:
+
+```bash
+python simulate.py random_walk --steps 300 --paths 3 --output random_walk.png
+```
+
+To inspect the configuration options for the Ornstein-Uhlenbeck process:
+
+```bash
+python simulate.py ornstein_uhlenbeck --help
+```
+
+By default the command prints a short numerical summary of the simulated sample
+paths. Use `--show` to display the plot in an interactive window (requires a
+matplotlib backend with GUI support) or `--output <file>` to save the plot.
+
+## Included processes
+
+The following processes are currently implemented:
+
+| Identifier | Category | Description |
+| ---------- | -------- | ----------- |
+| `random_walk` | Discrete-time | Simple random walk with configurable step probability and magnitude. |
+| `ar1` | Discrete-time | Gaussian autoregressive process of order one. |
+| `brownian_motion` | Continuous-time | Brownian motion with optional drift and volatility adjustments. |
+| `geometric_brownian_motion` | Continuous-time | Geometric Brownian motion, a common financial diffusion. |
+| `poisson_process` | Continuous-time | Homogeneous Poisson counting process. |
+| `ornstein_uhlenbeck` | Continuous-time | Mean-reverting Ornstein-Uhlenbeck diffusion. |
+
+Each process exposes intuitive parameters such as the number of steps, drift,
+volatility, intensity, or initial conditions. Refer to the per-process help for
+the exact defaults.
+
+## Development
+
+The code resides in the `stochastic_processes` package and is orchestrated by
+`simulate.py`. Running `python -m compileall .` ensures that all modules are
+syntactically valid.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib>=3.7
+numpy>=1.24

--- a/simulate.py
+++ b/simulate.py
@@ -1,0 +1,164 @@
+"""Command line entry point for the stochastic process simulator."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Dict, List
+
+import numpy as np
+
+from stochastic_processes.processes import (
+    AVAILABLE_PROCESSES,
+    ProcessDefinition,
+    ProcessParameter,
+)
+from stochastic_processes.plotting import plot_simulation
+
+
+def _list_processes() -> None:
+    """Print a summary of the processes available in the registry."""
+
+    print("Available stochastic processes:\n")
+    for key, definition in AVAILABLE_PROCESSES.items():
+        print(f"- {key} ({definition.category})\n  {definition.title}\n  {definition.description}\n")
+
+
+def _build_base_parser() -> argparse.ArgumentParser:
+    formatter = argparse.ArgumentDefaultsHelpFormatter
+    parser = argparse.ArgumentParser(
+        description="Simulate sample paths for discrete and continuous stochastic processes.",
+        formatter_class=formatter,
+    )
+    parser.add_argument(
+        "process",
+        nargs="?",
+        choices=list(AVAILABLE_PROCESSES.keys()),
+        help="Identifier of the process to simulate (use --list to see options).",
+    )
+    parser.add_argument(
+        "--paths",
+        type=int,
+        default=1,
+        help="Number of independent sample paths to generate.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Seed for the pseudo-random number generator.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Optional destination file for the generated figure (e.g. output.png).",
+    )
+    parser.add_argument(
+        "--show",
+        action="store_true",
+        help="Display the resulting plot in an interactive window.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List the available processes and exit.",
+    )
+    return parser
+
+
+def _build_process_parser(definition: ProcessDefinition) -> argparse.ArgumentParser:
+    formatter = argparse.ArgumentDefaultsHelpFormatter
+    parser = argparse.ArgumentParser(
+        description=f"{definition.title}\n\n{definition.description}",
+        formatter_class=formatter,
+    )
+    for parameter in definition.parameters:
+        argument_name = f"--{parameter.name.replace('_', '-')}"
+        kwargs: Dict[str, object] = {
+            "type": parameter.type,
+            "default": parameter.default,
+            "help": parameter.help,
+        }
+        if parameter.choices:
+            kwargs["choices"] = parameter.choices
+        parser.add_argument(argument_name, **kwargs)
+    return parser
+
+
+def _validate_paths(count: int, parser: argparse.ArgumentParser) -> None:
+    if count < 1:
+        parser.error("--paths must be at least 1.")
+
+
+def _apply_validators(
+    values: argparse.Namespace,
+    parameters: List[ProcessParameter],
+) -> None:
+    for parameter in parameters:
+        validator = parameter.validator
+        if validator is None:
+            continue
+        value = getattr(values, parameter.name)
+        try:
+            validator(value)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def main(argv: List[str] | None = None) -> int:
+    base_parser = _build_base_parser()
+    args, remaining = base_parser.parse_known_args(argv)
+
+    if args.list:
+        _list_processes()
+        return 0
+
+    if args.process is None:
+        base_parser.print_help(sys.stderr)
+        return 1
+
+    _validate_paths(args.paths, base_parser)
+
+    definition = AVAILABLE_PROCESSES[args.process]
+    process_parser = _build_process_parser(definition)
+    process_args = process_parser.parse_args(remaining)
+    try:
+        _apply_validators(process_args, list(definition.parameters))
+    except argparse.ArgumentTypeError as exc:
+        process_parser.error(str(exc))
+
+    options = {parameter.name: getattr(process_args, parameter.name) for parameter in definition.parameters}
+
+    try:
+        result = definition.simulate(
+            n_paths=args.paths,
+            seed=args.seed,
+            **options,
+        )
+    except ValueError as exc:
+        base_parser.error(str(exc))
+
+    plot_simulation(result, output=args.output, show=args.show)
+
+    summary = result.parameter_summary()
+    endpoints = result.paths[:, -1]
+    mean_endpoint = float(np.mean(endpoints))
+    std_endpoint = float(np.std(endpoints))
+    print(
+        f"Simulated {definition.title} with {args.paths} path(s). "
+        f"Final value mean={mean_endpoint:.3f}, std={std_endpoint:.3f}."
+    )
+    if summary:
+        print(f"Parameters: {summary}")
+    if args.output:
+        print(f"Plot written to {args.output}")
+    elif not args.show:
+        print("No output file requested; use --output to save the figure or --show to display it.")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())
+

--- a/stochastic_processes/__init__.py
+++ b/stochastic_processes/__init__.py
@@ -1,0 +1,15 @@
+"""Utilities for simulating and visualising stochastic processes.
+
+This package exposes the available process registry and the plotting helper
+that backs the command line interface defined in :mod:`simulate`.
+"""
+
+from .processes import AVAILABLE_PROCESSES, ProcessDefinition, SimulationResult
+from .plotting import plot_simulation
+
+__all__ = [
+    "AVAILABLE_PROCESSES",
+    "ProcessDefinition",
+    "SimulationResult",
+    "plot_simulation",
+]

--- a/stochastic_processes/plotting.py
+++ b/stochastic_processes/plotting.py
@@ -1,0 +1,101 @@
+"""Plotting helpers for stochastic process simulations."""
+
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+import matplotlib
+
+from .processes import SimulationResult
+
+
+def _load_pyplot(show: bool):
+    """Load :mod:`matplotlib.pyplot` with a backend suitable for the environment."""
+
+    if "matplotlib.pyplot" in sys.modules:
+        import matplotlib.pyplot as plt  # type: ignore
+
+        return plt
+
+    if not show:
+        matplotlib.use("Agg", force=True)
+
+    import matplotlib.pyplot as plt  # type: ignore
+
+    return plt
+
+
+def plot_simulation(
+    result: SimulationResult,
+    *,
+    output: Optional[str] = None,
+    show: bool = False,
+) -> Optional[str]:
+    """Render the sample paths of a simulation result.
+
+    Parameters
+    ----------
+    result:
+        The outcome returned by the simulator.
+    output:
+        Optional path where the figure should be written.
+    show:
+        Whether to display the figure using :func:`matplotlib.pyplot.show`.
+
+    Returns
+    -------
+    Optional[str]
+        The path of the written figure when ``output`` is provided.
+    """
+
+    plt = _load_pyplot(show)
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    style = result.metadata.get("plot_style", "line")
+    x_label = result.metadata.get("x_label", "Time")
+    y_label = result.metadata.get("y_label", "Value")
+
+    for index, path in enumerate(result.paths):
+        label = None
+        if result.paths.shape[0] > 1:
+            label = f"Path {index + 1}"
+
+        if style == "step":
+            ax.step(result.times, path, where="post", alpha=0.85, linewidth=1.5, label=label)
+        else:
+            ax.plot(result.times, path, alpha=0.9, linewidth=1.5, label=label)
+
+    ax.set_title(result.name)
+    ax.set_xlabel(x_label)
+    ax.set_ylabel(y_label)
+
+    if result.paths.shape[0] > 1:
+        ax.legend(loc="best", frameon=False)
+
+    parameter_summary = result.parameter_summary()
+    if parameter_summary:
+        ax.text(
+            0.5,
+            -0.2,
+            parameter_summary,
+            ha="center",
+            va="top",
+            transform=ax.transAxes,
+            fontsize=9,
+            color="#333333",
+        )
+
+    ax.grid(True, which="both", linestyle="--", linewidth=0.5, alpha=0.5)
+    fig.tight_layout(rect=(0, 0.05, 1, 1))
+
+    if output:
+        fig.savefig(output, bbox_inches="tight")
+
+    if show:
+        plt.show()
+    else:
+        plt.close(fig)
+
+    return output
+

--- a/stochastic_processes/processes.py
+++ b/stochastic_processes/processes.py
@@ -1,0 +1,595 @@
+"""Definitions of stochastic processes supported by the simulator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Mapping, MutableMapping, Optional, Sequence
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class SimulationResult:
+    """Container holding the outcome of a stochastic process simulation."""
+
+    name: str
+    times: np.ndarray
+    paths: np.ndarray
+    description: str
+    parameters: Mapping[str, Any]
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def parameter_summary(self) -> str:
+        """Return a human readable summary of the simulation parameters."""
+
+        if not self.parameters:
+            return ""
+        ordered = ", ".join(f"{key}={value}" for key, value in self.parameters.items())
+        return ordered
+
+
+ParameterType = Callable[[str], Any]
+
+
+@dataclass(frozen=True)
+class ProcessParameter:
+    """Description of a single argument exposed by a stochastic process."""
+
+    name: str
+    type: ParameterType
+    default: Any
+    help: str
+    choices: Optional[Sequence[Any]] = None
+    validator: Optional[Callable[[Any], None]] = None
+
+
+@dataclass(frozen=True)
+class ProcessDefinition:
+    """Metadata and implementation details for an available process."""
+
+    key: str
+    title: str
+    description: str
+    category: str
+    parameters: Sequence[ProcessParameter]
+    simulator: Callable[..., SimulationResult]
+
+    def simulate(self, *, n_paths: int, seed: Optional[int], **kwargs: Any) -> SimulationResult:
+        """Execute the simulator associated with this definition."""
+
+        return self.simulator(n_paths=n_paths, seed=seed, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Process implementations
+# ---------------------------------------------------------------------------
+
+def _validate_positive(value: float, name: str) -> None:
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, received {value}.")
+
+
+def _validate_non_negative(value: float, name: str) -> None:
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative, received {value}.")
+
+
+def _validate_probability(value: float, name: str = "p") -> None:
+    if not 0 <= value <= 1:
+        raise ValueError(f"{name} must be between 0 and 1, received {value}.")
+
+
+def _validate_num_paths(n_paths: int) -> None:
+    if n_paths < 1:
+        raise ValueError("At least one sample path must be generated.")
+
+
+def _prepare_rng(seed: Optional[int]) -> np.random.Generator:
+    return np.random.default_rng(seed)
+
+
+def _random_walk(
+    *,
+    steps: int = 250,
+    p: float = 0.5,
+    step_size: float = 1.0,
+    n_paths: int,
+    seed: Optional[int],
+) -> SimulationResult:
+    if steps <= 0:
+        raise ValueError("steps must be a positive integer.")
+    _validate_probability(p, "p")
+    _validate_positive(step_size, "step_size")
+    _validate_num_paths(n_paths)
+
+    rng = _prepare_rng(seed)
+    increments = rng.choice(
+        np.array([step_size, -step_size]),
+        size=(n_paths, steps),
+        p=[p, 1 - p],
+    )
+    cumulative = np.concatenate(
+        [np.zeros((n_paths, 1)), np.cumsum(increments, axis=1)], axis=1
+    )
+    times = np.arange(steps + 1)
+    metadata = {
+        "plot_style": "step",
+        "x_label": "Step",
+        "y_label": "Position",
+    }
+    return SimulationResult(
+        name="Simple Random Walk",
+        times=times,
+        paths=cumulative,
+        description=(
+            "Discrete-time process that adds ±step_size increments with "
+            f"probability p={p}."
+        ),
+        parameters={"steps": steps, "p": p, "step_size": step_size},
+        metadata=metadata,
+    )
+
+
+def _autoregressive(
+    *,
+    steps: int = 250,
+    phi: float = 0.8,
+    sigma: float = 1.0,
+    x0: float = 0.0,
+    n_paths: int,
+    seed: Optional[int],
+) -> SimulationResult:
+    if steps <= 0:
+        raise ValueError("steps must be a positive integer.")
+    _validate_non_negative(sigma, "sigma")
+    _validate_num_paths(n_paths)
+
+    rng = _prepare_rng(seed)
+    epsilon = rng.normal(loc=0.0, scale=sigma, size=(n_paths, steps))
+    paths = np.zeros((n_paths, steps + 1))
+    paths[:, 0] = x0
+    for t in range(steps):
+        paths[:, t + 1] = phi * paths[:, t] + epsilon[:, t]
+    times = np.arange(steps + 1)
+    metadata = {"plot_style": "line", "x_label": "Step", "y_label": "Value"}
+    return SimulationResult(
+        name="Autoregressive AR(1)",
+        times=times,
+        paths=paths,
+        description=(
+            "Discrete-time process X_t = phi * X_{t-1} + epsilon_t where the "
+            "innovations are Gaussian."
+        ),
+        parameters={"steps": steps, "phi": phi, "sigma": sigma, "x0": x0},
+        metadata=metadata,
+    )
+
+
+def _brownian_motion(
+    *,
+    t_max: float = 1.0,
+    steps: int = 500,
+    mu: float = 0.0,
+    sigma: float = 1.0,
+    x0: float = 0.0,
+    n_paths: int,
+    seed: Optional[int],
+) -> SimulationResult:
+    _validate_positive(t_max, "t_max")
+    if steps <= 0:
+        raise ValueError("steps must be a positive integer.")
+    _validate_non_negative(sigma, "sigma")
+    _validate_num_paths(n_paths)
+
+    rng = _prepare_rng(seed)
+    dt = t_max / steps
+    increments = rng.normal(
+        loc=mu * dt,
+        scale=sigma * np.sqrt(dt),
+        size=(n_paths, steps),
+    )
+    paths = np.concatenate(
+        [np.full((n_paths, 1), x0), x0 + np.cumsum(increments, axis=1)], axis=1
+    )
+    times = np.linspace(0.0, t_max, steps + 1)
+    metadata = {
+        "plot_style": "line",
+        "x_label": "Time",
+        "y_label": "Value",
+    }
+    return SimulationResult(
+        name="Brownian Motion",
+        times=times,
+        paths=paths,
+        description=(
+            "Continuous-time process with normally distributed increments and "
+            "variance growing linearly with time."
+        ),
+        parameters={
+            "t_max": t_max,
+            "steps": steps,
+            "mu": mu,
+            "sigma": sigma,
+            "x0": x0,
+        },
+        metadata=metadata,
+    )
+
+
+def _geometric_brownian(
+    *,
+    t_max: float = 1.0,
+    steps: int = 500,
+    mu: float = 0.1,
+    sigma: float = 0.2,
+    s0: float = 1.0,
+    n_paths: int,
+    seed: Optional[int],
+) -> SimulationResult:
+    _validate_positive(t_max, "t_max")
+    if steps <= 0:
+        raise ValueError("steps must be a positive integer.")
+    _validate_non_negative(sigma, "sigma")
+    _validate_positive(s0, "s0")
+    _validate_num_paths(n_paths)
+
+    rng = _prepare_rng(seed)
+    dt = t_max / steps
+    drift = (mu - 0.5 * sigma ** 2) * dt
+    diffusion = sigma * np.sqrt(dt)
+    shocks = rng.normal(loc=0.0, scale=1.0, size=(n_paths, steps))
+    log_returns = drift + diffusion * shocks
+    cumulative_log_returns = np.concatenate(
+        [np.zeros((n_paths, 1)), np.cumsum(log_returns, axis=1)], axis=1
+    )
+    paths = s0 * np.exp(cumulative_log_returns)
+    times = np.linspace(0.0, t_max, steps + 1)
+    metadata = {
+        "plot_style": "line",
+        "x_label": "Time",
+        "y_label": "Value",
+    }
+    return SimulationResult(
+        name="Geometric Brownian Motion",
+        times=times,
+        paths=paths,
+        description=(
+            "Continuous-time process commonly used for modelling asset prices."
+        ),
+        parameters={
+            "t_max": t_max,
+            "steps": steps,
+            "mu": mu,
+            "sigma": sigma,
+            "s0": s0,
+        },
+        metadata=metadata,
+    )
+
+
+def _poisson_process(
+    *,
+    rate: float = 5.0,
+    t_max: float = 10.0,
+    steps: int = 500,
+    n_paths: int,
+    seed: Optional[int],
+) -> SimulationResult:
+    _validate_positive(rate, "rate")
+    _validate_positive(t_max, "t_max")
+    if steps <= 0:
+        raise ValueError("steps must be a positive integer.")
+    _validate_num_paths(n_paths)
+
+    rng = _prepare_rng(seed)
+    dt = t_max / steps
+    increments = rng.poisson(lam=rate * dt, size=(n_paths, steps))
+    paths = np.concatenate(
+        [np.zeros((n_paths, 1)), np.cumsum(increments, axis=1)], axis=1
+    )
+    times = np.linspace(0.0, t_max, steps + 1)
+    metadata = {
+        "plot_style": "step",
+        "x_label": "Time",
+        "y_label": "Event count",
+    }
+    return SimulationResult(
+        name="Poisson Process",
+        times=times,
+        paths=paths,
+        description=(
+            "Counting process with exponentially distributed inter-arrival times."
+        ),
+        parameters={"rate": rate, "t_max": t_max, "steps": steps},
+        metadata=metadata,
+    )
+
+
+def _ornstein_uhlenbeck(
+    *,
+    t_max: float = 5.0,
+    steps: int = 500,
+    theta: float = 1.0,
+    mu: float = 0.0,
+    sigma: float = 0.3,
+    x0: float = 0.0,
+    n_paths: int,
+    seed: Optional[int],
+) -> SimulationResult:
+    _validate_positive(t_max, "t_max")
+    if steps <= 0:
+        raise ValueError("steps must be a positive integer.")
+    _validate_positive(theta, "theta")
+    _validate_non_negative(sigma, "sigma")
+    _validate_num_paths(n_paths)
+
+    rng = _prepare_rng(seed)
+    dt = t_max / steps
+    shocks = rng.normal(loc=0.0, scale=np.sqrt(dt), size=(n_paths, steps))
+    paths = np.zeros((n_paths, steps + 1))
+    paths[:, 0] = x0
+    for t in range(steps):
+        paths[:, t + 1] = (
+            paths[:, t]
+            + theta * (mu - paths[:, t]) * dt
+            + sigma * shocks[:, t]
+        )
+    times = np.linspace(0.0, t_max, steps + 1)
+    metadata = {
+        "plot_style": "line",
+        "x_label": "Time",
+        "y_label": "Value",
+    }
+    return SimulationResult(
+        name="Ornstein-Uhlenbeck Process",
+        times=times,
+        paths=paths,
+        description="Mean-reverting continuous-time Gaussian process.",
+        parameters={
+            "t_max": t_max,
+            "steps": steps,
+            "theta": theta,
+            "mu": mu,
+            "sigma": sigma,
+            "x0": x0,
+        },
+        metadata=metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Process registry
+# ---------------------------------------------------------------------------
+
+AVAILABLE_PROCESSES: Dict[str, ProcessDefinition] = {
+    "random_walk": ProcessDefinition(
+        key="random_walk",
+        title="Simple Random Walk",
+        description="Classic ±1 walk with configurable probability and step size.",
+        category="discrete-time",
+        parameters=[
+            ProcessParameter(
+                name="steps",
+                type=int,
+                default=250,
+                help="Number of steps to simulate.",
+                validator=lambda value: _validate_positive(value, "steps"),
+            ),
+            ProcessParameter(
+                name="p",
+                type=float,
+                default=0.5,
+                help="Probability of taking a positive step.",
+                validator=lambda value: _validate_probability(value, "p"),
+            ),
+            ProcessParameter(
+                name="step_size",
+                type=float,
+                default=1.0,
+                help="Magnitude of each step.",
+                validator=lambda value: _validate_positive(value, "step_size"),
+            ),
+        ],
+        simulator=_random_walk,
+    ),
+    "ar1": ProcessDefinition(
+        key="ar1",
+        title="Autoregressive AR(1)",
+        description="Discrete-time Gaussian AR(1) process.",
+        category="discrete-time",
+        parameters=[
+            ProcessParameter(
+                name="steps",
+                type=int,
+                default=250,
+                help="Number of observations to generate.",
+                validator=lambda value: _validate_positive(value, "steps"),
+            ),
+            ProcessParameter(
+                name="phi",
+                type=float,
+                default=0.8,
+                help="Autoregressive coefficient.",
+            ),
+            ProcessParameter(
+                name="sigma",
+                type=float,
+                default=1.0,
+                help="Standard deviation of the innovation term.",
+                validator=lambda value: _validate_non_negative(value, "sigma"),
+            ),
+            ProcessParameter(
+                name="x0",
+                type=float,
+                default=0.0,
+                help="Initial value of the process.",
+            ),
+        ],
+        simulator=_autoregressive,
+    ),
+    "brownian_motion": ProcessDefinition(
+        key="brownian_motion",
+        title="Brownian Motion",
+        description="Continuous-time Brownian motion with drift.",
+        category="continuous-time",
+        parameters=[
+            ProcessParameter(
+                name="t_max",
+                type=float,
+                default=1.0,
+                help="Time horizon for the simulation.",
+                validator=lambda value: _validate_positive(value, "t_max"),
+            ),
+            ProcessParameter(
+                name="steps",
+                type=int,
+                default=500,
+                help="Number of discretisation steps.",
+                validator=lambda value: _validate_positive(value, "steps"),
+            ),
+            ProcessParameter(
+                name="mu",
+                type=float,
+                default=0.0,
+                help="Drift term of the process.",
+            ),
+            ProcessParameter(
+                name="sigma",
+                type=float,
+                default=1.0,
+                help="Volatility parameter.",
+                validator=lambda value: _validate_non_negative(value, "sigma"),
+            ),
+            ProcessParameter(
+                name="x0",
+                type=float,
+                default=0.0,
+                help="Initial value of the process.",
+            ),
+        ],
+        simulator=_brownian_motion,
+    ),
+    "geometric_brownian_motion": ProcessDefinition(
+        key="geometric_brownian_motion",
+        title="Geometric Brownian Motion",
+        description="Exponentially scaled Brownian motion used in finance.",
+        category="continuous-time",
+        parameters=[
+            ProcessParameter(
+                name="t_max",
+                type=float,
+                default=1.0,
+                help="Time horizon for the simulation.",
+                validator=lambda value: _validate_positive(value, "t_max"),
+            ),
+            ProcessParameter(
+                name="steps",
+                type=int,
+                default=500,
+                help="Number of discretisation steps.",
+                validator=lambda value: _validate_positive(value, "steps"),
+            ),
+            ProcessParameter(
+                name="mu",
+                type=float,
+                default=0.1,
+                help="Expected return / drift term.",
+            ),
+            ProcessParameter(
+                name="sigma",
+                type=float,
+                default=0.2,
+                help="Volatility parameter.",
+                validator=lambda value: _validate_non_negative(value, "sigma"),
+            ),
+            ProcessParameter(
+                name="s0",
+                type=float,
+                default=1.0,
+                help="Initial asset level.",
+                validator=lambda value: _validate_positive(value, "s0"),
+            ),
+        ],
+        simulator=_geometric_brownian,
+    ),
+    "poisson_process": ProcessDefinition(
+        key="poisson_process",
+        title="Poisson Process",
+        description="Counting process with a constant intensity.",
+        category="continuous-time",
+        parameters=[
+            ProcessParameter(
+                name="rate",
+                type=float,
+                default=5.0,
+                help="Intensity (events per unit time).",
+                validator=lambda value: _validate_positive(value, "rate"),
+            ),
+            ProcessParameter(
+                name="t_max",
+                type=float,
+                default=10.0,
+                help="Time horizon for the simulation.",
+                validator=lambda value: _validate_positive(value, "t_max"),
+            ),
+            ProcessParameter(
+                name="steps",
+                type=int,
+                default=500,
+                help="Number of discretisation steps.",
+                validator=lambda value: _validate_positive(value, "steps"),
+            ),
+        ],
+        simulator=_poisson_process,
+    ),
+    "ornstein_uhlenbeck": ProcessDefinition(
+        key="ornstein_uhlenbeck",
+        title="Ornstein-Uhlenbeck",
+        description="Mean-reverting Gaussian diffusion.",
+        category="continuous-time",
+        parameters=[
+            ProcessParameter(
+                name="t_max",
+                type=float,
+                default=5.0,
+                help="Time horizon for the simulation.",
+                validator=lambda value: _validate_positive(value, "t_max"),
+            ),
+            ProcessParameter(
+                name="steps",
+                type=int,
+                default=500,
+                help="Number of discretisation steps.",
+                validator=lambda value: _validate_positive(value, "steps"),
+            ),
+            ProcessParameter(
+                name="theta",
+                type=float,
+                default=1.0,
+                help="Speed of mean reversion.",
+                validator=lambda value: _validate_positive(value, "theta"),
+            ),
+            ProcessParameter(
+                name="mu",
+                type=float,
+                default=0.0,
+                help="Long-run mean of the process.",
+            ),
+            ProcessParameter(
+                name="sigma",
+                type=float,
+                default=0.3,
+                help="Volatility parameter.",
+                validator=lambda value: _validate_non_negative(value, "sigma"),
+            ),
+            ProcessParameter(
+                name="x0",
+                type=float,
+                default=0.0,
+                help="Initial value of the process.",
+            ),
+        ],
+        simulator=_ornstein_uhlenbeck,
+    ),
+}
+


### PR DESCRIPTION
## Summary
- add a reusable package with stochastic process simulations and registry metadata
- implement matplotlib-based plotting helpers and a CLI driver with process-specific arguments
- document usage instructions and provide a requirements file for the new tool

## Testing
- `python -m compileall .`


------
https://chatgpt.com/codex/tasks/task_e_68cdd2c7c61c8322b7b78ef6b21e6c5b