### PR TITLE
Add stochastic process simulator CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,77 @@
 # Stochastic-Prossesses
-Calculator/plotter of stochastic processes
+
+A lightweight simulator and plotter for common discrete- and continuous-time
+stochastic processes. The command line interface lets you pick a process,
+customise its parameters, and either display or save the simulated sample
+paths.
+
+## Features
+
+- Discrete-time processes: simple random walk, autoregressive AR(1) process,
+  and a two-state Markov chain.
+- Continuous-time processes: Poisson process, Brownian motion, geometric
+  Brownian motion, and Ornstein-Uhlenbeck diffusion.
+- Configurable number of steps, time horizon, distribution parameters, and
+  number of simulated sample paths.
+- Generates publication-ready Matplotlib graphs that can be shown
+  interactively or exported to an image file.
+
+## Getting started
+
+1. **Install dependencies**
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. **List available processes**
+
+   ```bash
+   python simulate.py --process simple_random_walk --help
+   ```
+
+   The help output includes an epilog that lists every process with a short
+   description and shows the parameters that can be overridden via the
+   `--param` flag.
+
+3. **Run a simulation**
+
+   Override any parameter by using the `--param name=value` flag (it can be
+   supplied multiple times). Example: simulate an Ornstein-Uhlenbeck process
+   and save the output plot to `ou.png`.
+
+   ```bash
+   python simulate.py --process ornstein_uhlenbeck \
+       --param theta=1.5 --param sigma=0.5 --param paths=10 \
+       --output ou.png --no-show
+   ```
+
+   To simply visualise a process interactively, omit the `--output` flag and
+   the plot window will open after the simulation finishes.
+
+## Development
+
+The simulator is organised as a small Python package inside the
+`stochastic_processes` directory. The most important modules are:
+
+- `discrete.py` and `continuous.py`: implementations of each process.
+- `registry.py`: metadata describing the processes and their parameters.
+- `plotting.py`: helper to generate Matplotlib figures from a simulation.
+
+You can import the package in your own Python code to reuse the simulations:
+
+```python
+from stochastic_processes import simulate_process
+
+result = simulate_process("poisson_process", {"rate": 3.0, "paths": 2})
+print(result.time)
+print(result.values)
+```
+
+Run the tests to ensure everything works as expected:
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib>=3.5
+numpy>=1.21

--- a/simulate.py
+++ b/simulate.py
@@ -1,0 +1,93 @@
+"""Command line interface for the stochastic process simulator."""
+
+from __future__ import annotations
+
+import argparse
+import textwrap
+from typing import Dict
+
+from stochastic_processes import PROCESS_REGISTRY, get_process_spec, list_processes, simulate_process
+from stochastic_processes.plotting import plot_simulation
+
+
+def _format_process_listing() -> str:
+    lines = []
+    for spec in list_processes():
+        lines.append(f"- {spec.key}: {spec.name} ({spec.category})")
+        lines.append(textwrap.indent(textwrap.fill(spec.description, width=80), prefix="  "))
+    return "\n".join(lines)
+
+
+def _parse_params(spec_key: str, params: list[str]) -> Dict[str, object]:
+    spec = get_process_spec(spec_key)
+    overrides: Dict[str, object] = {}
+    for item in params:
+        if "=" not in item:
+            raise ValueError(
+                f"Could not parse parameter override '{item}'. Expected the form name=value."
+            )
+        name, raw_value = item.split("=", 1)
+        name = name.strip()
+        if name not in spec.parameters:
+            raise KeyError(f"Unknown parameter '{name}' for process '{spec_key}'.")
+        overrides[name] = spec.parameters[name].parse(raw_value.strip())
+    return overrides
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Simulate and plot discrete and continuous time stochastic processes.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="Available processes:\n" + _format_process_listing(),
+    )
+    parser.add_argument(
+        "--process",
+        required=True,
+        choices=sorted(PROCESS_REGISTRY.keys()),
+        help="Identifier of the process to simulate. Use the epilog list for options.",
+    )
+    parser.add_argument(
+        "--param",
+        action="append",
+        default=[],
+        metavar="name=value",
+        help="Override one of the process parameters (can be provided multiple times).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Seed for the random number generator to obtain reproducible simulations.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Path of the image file where the plot should be stored. If omitted the plot is shown.",
+    )
+    parser.add_argument(
+        "--no-show",
+        action="store_true",
+        help="Disable interactive display of the plot (useful when saving to a file).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    overrides = _parse_params(args.process, args.param)
+    result = simulate_process(args.process, overrides=overrides, seed=args.seed)
+    spec = get_process_spec(args.process)
+
+    plot_simulation(
+        result,
+        spec,
+        output_path=args.output,
+        show=not args.no_show and args.output is None,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/stochastic_processes/__init__.py
+++ b/stochastic_processes/__init__.py
@@ -1,0 +1,14 @@
+"""Utilities for simulating and plotting stochastic processes."""
+
+from .base import ParameterSpec, ProcessSpec, SimulationResult
+from .registry import PROCESS_REGISTRY, simulate_process, list_processes, get_process_spec
+
+__all__ = [
+    "ParameterSpec",
+    "ProcessSpec",
+    "SimulationResult",
+    "PROCESS_REGISTRY",
+    "simulate_process",
+    "list_processes",
+    "get_process_spec",
+]

--- a/stochastic_processes/base.py
+++ b/stochastic_processes/base.py
@@ -1,0 +1,121 @@
+"""Base data structures used by the stochastic process simulator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence
+
+import numpy as np
+
+
+@dataclass
+class SimulationResult:
+    """Holds the outcome of a stochastic process simulation.
+
+    Attributes
+    ----------
+    time:
+        One dimensional array describing the time or step index.
+    values:
+        Two dimensional array with shape ``(paths, len(time))`` describing the
+        simulated sample paths.
+    metadata:
+        Arbitrary metadata about the simulation (for example parameter values
+        used to generate the paths).
+    """
+
+    time: np.ndarray
+    values: np.ndarray
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.time.ndim != 1:
+            raise ValueError("time must be a 1-D array")
+        if self.values.ndim != 2:
+            raise ValueError("values must be a 2-D array")
+        if self.values.shape[1] != self.time.shape[0]:
+            raise ValueError(
+                "values second dimension must equal the length of the time axis"
+            )
+
+
+@dataclass
+class ParameterSpec:
+    """Specification of a configurable parameter for a stochastic process."""
+
+    name: str
+    type: Callable[[str], Any]
+    default: Any
+    help: str
+    choices: Optional[Sequence[Any]] = None
+    validator: Optional[Callable[[Any], None]] = None
+
+    def parse(self, raw: str) -> Any:
+        """Parse a string representation into the correct data type.
+
+        Parameters
+        ----------
+        raw:
+            String provided by the user.
+        """
+
+        value = self.type(raw)
+        if self.choices is not None and value not in self.choices:
+            raise ValueError(
+                f"Invalid value '{value}' for parameter '{self.name}'. "
+                f"Allowed values are: {self.choices}."
+            )
+        if self.validator is not None:
+            self.validator(value)
+        return value
+
+
+@dataclass
+class ProcessSpec:
+    """Metadata and callable for a stochastic process simulation."""
+
+    key: str
+    name: str
+    category: str
+    description: str
+    simulator: Callable[[Mapping[str, Any], Optional[int]], SimulationResult]
+    parameters: Mapping[str, ParameterSpec]
+    time_label: str = "Time"
+    value_label: str = "Value"
+
+    def coerce_parameters(self, overrides: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
+        """Combine default values with optional overrides."""
+
+        values: Dict[str, Any] = {name: spec.default for name, spec in self.parameters.items()}
+        if overrides:
+            for name, value in overrides.items():
+                if name not in self.parameters:
+                    raise KeyError(f"Unknown parameter '{name}' for process '{self.key}'.")
+                spec = self.parameters[name]
+                if isinstance(value, str):
+                    value = spec.parse(value)
+                else:
+                    if spec.choices is not None and value not in spec.choices:
+                        raise ValueError(
+                            f"Invalid value '{value}' for parameter '{name}'. "
+                            f"Allowed values are: {spec.choices}."
+                        )
+                    if spec.validator is not None:
+                        spec.validator(value)
+                values[name] = value
+        return values
+
+
+def positive_int(value: int) -> None:
+    if value <= 0:
+        raise ValueError("value must be a positive integer")
+
+
+def positive_float(value: float) -> None:
+    if value <= 0:
+        raise ValueError("value must be a positive number")
+
+
+def probability(value: float) -> None:
+    if value < 0 or value > 1:
+        raise ValueError("probability values must be within [0, 1]")

--- a/stochastic_processes/continuous.py
+++ b/stochastic_processes/continuous.py
@@ -1,0 +1,139 @@
+"""Continuous time stochastic process simulators."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import numpy as np
+
+from .base import SimulationResult
+
+
+def _time_grid(t_max: float, dt: float) -> np.ndarray:
+    steps = int(np.ceil(t_max / dt))
+    return np.linspace(0.0, steps * dt, steps + 1)
+
+
+def simulate_poisson_process(params: Dict[str, float], seed: Optional[int] = None) -> SimulationResult:
+    """Simulate a Poisson counting process."""
+
+    rate = float(params["rate"])
+    t_max = float(params["t_max"])
+    dt = float(params["dt"])
+    paths = int(params["paths"])
+
+    time = _time_grid(t_max, dt)
+    num_steps = time.size - 1
+    rng = np.random.default_rng(seed)
+    increments = rng.poisson(rate * dt, size=(paths, num_steps))
+    counts = np.concatenate([
+        np.zeros((paths, 1), dtype=float),
+        np.cumsum(increments, axis=1),
+    ], axis=1)
+    metadata = {
+        "rate": rate,
+        "t_max": float(time[-1]),
+        "dt": dt,
+        "paths": paths,
+        "process": "poisson_process",
+    }
+    return SimulationResult(time=time, values=counts, metadata=metadata)
+
+
+def simulate_brownian_motion(params: Dict[str, float], seed: Optional[int] = None) -> SimulationResult:
+    """Simulate a Brownian motion with optional drift and volatility."""
+
+    drift = float(params["drift"])
+    volatility = float(params["volatility"])
+    t_max = float(params["t_max"])
+    dt = float(params["dt"])
+    paths = int(params["paths"])
+
+    time = _time_grid(t_max, dt)
+    num_steps = time.size - 1
+    rng = np.random.default_rng(seed)
+    increments = rng.normal(loc=0.0, scale=np.sqrt(dt), size=(paths, num_steps))
+    paths_values = np.concatenate([
+        np.zeros((paths, 1), dtype=float),
+        np.cumsum(increments, axis=1),
+    ], axis=1)
+    values = drift * time + volatility * paths_values
+    metadata = {
+        "drift": drift,
+        "volatility": volatility,
+        "t_max": float(time[-1]),
+        "dt": dt,
+        "paths": paths,
+        "process": "brownian_motion",
+    }
+    return SimulationResult(time=time, values=values, metadata=metadata)
+
+
+def simulate_geometric_brownian_motion(
+    params: Dict[str, float], seed: Optional[int] = None
+) -> SimulationResult:
+    """Simulate a geometric Brownian motion (commonly used in finance)."""
+
+    mu = float(params["mu"])
+    sigma = float(params["sigma"])
+    initial = float(params["initial"])
+    t_max = float(params["t_max"])
+    dt = float(params["dt"])
+    paths = int(params["paths"])
+
+    time = _time_grid(t_max, dt)
+    num_steps = time.size - 1
+    rng = np.random.default_rng(seed)
+    normal_increments = rng.normal(loc=0.0, scale=np.sqrt(dt), size=(paths, num_steps))
+    increments = (mu - 0.5 * sigma ** 2) * dt + sigma * normal_increments
+    log_paths = np.concatenate([
+        np.zeros((paths, 1), dtype=float),
+        np.cumsum(increments, axis=1),
+    ], axis=1)
+    values = initial * np.exp(log_paths)
+    metadata = {
+        "mu": mu,
+        "sigma": sigma,
+        "initial": initial,
+        "t_max": float(time[-1]),
+        "dt": dt,
+        "paths": paths,
+        "process": "geometric_brownian_motion",
+    }
+    return SimulationResult(time=time, values=values, metadata=metadata)
+
+
+def simulate_ornstein_uhlenbeck(params: Dict[str, float], seed: Optional[int] = None) -> SimulationResult:
+    """Simulate an Ornstein-Uhlenbeck mean-reverting process."""
+
+    theta = float(params["theta"])
+    mu = float(params["mu"])
+    sigma = float(params["sigma"])
+    initial = float(params["initial"])
+    t_max = float(params["t_max"])
+    dt = float(params["dt"])
+    paths = int(params["paths"])
+
+    time = _time_grid(t_max, dt)
+    num_steps = time.size - 1
+    rng = np.random.default_rng(seed)
+    normals = rng.normal(loc=0.0, scale=np.sqrt(dt), size=(paths, num_steps))
+    values = np.empty((paths, num_steps + 1), dtype=float)
+    values[:, 0] = initial
+    for t in range(1, num_steps + 1):
+        values[:, t] = (
+            values[:, t - 1]
+            + theta * (mu - values[:, t - 1]) * dt
+            + sigma * normals[:, t - 1]
+        )
+    metadata = {
+        "theta": theta,
+        "mu": mu,
+        "sigma": sigma,
+        "initial": initial,
+        "t_max": float(time[-1]),
+        "dt": dt,
+        "paths": paths,
+        "process": "ornstein_uhlenbeck",
+    }
+    return SimulationResult(time=time, values=values, metadata=metadata)

--- a/stochastic_processes/discrete.py
+++ b/stochastic_processes/discrete.py
@@ -1,0 +1,105 @@
+"""Discrete time stochastic process simulators."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import numpy as np
+
+from .base import SimulationResult
+
+
+def simulate_simple_random_walk(params: Dict[str, float], seed: Optional[int] = None) -> SimulationResult:
+    """Simulate a simple symmetric (or biased) random walk."""
+
+    steps = int(params["steps"])
+    start = float(params["start"])
+    p = float(params["p"])
+    paths = int(params["paths"])
+    step_size = float(params["step_size"])
+
+    rng = np.random.default_rng(seed)
+    increments = rng.choice(
+        [-step_size, step_size], size=(paths, steps), p=[1 - p, p]
+    )
+    start_column = np.full((paths, 1), start, dtype=float)
+    values = np.concatenate(
+        [start_column, start + np.cumsum(increments, axis=1)], axis=1
+    )
+    time = np.arange(steps + 1, dtype=int)
+    metadata = {
+        "steps": steps,
+        "start": start,
+        "p": p,
+        "paths": paths,
+        "step_size": step_size,
+        "process": "simple_random_walk",
+    }
+    return SimulationResult(time=time, values=values, metadata=metadata)
+
+
+def simulate_autoregressive(params: Dict[str, float], seed: Optional[int] = None) -> SimulationResult:
+    """Simulate an autoregressive AR(1) process."""
+
+    steps = int(params["steps"])
+    phi = float(params["phi"])
+    sigma = float(params["sigma"])
+    mean = float(params["mean"])
+    start = float(params["start"])
+    paths = int(params["paths"])
+
+    rng = np.random.default_rng(seed)
+    shocks = rng.normal(loc=0.0, scale=sigma, size=(paths, steps))
+    values = np.empty((paths, steps + 1), dtype=float)
+    values[:, 0] = start
+    for t in range(1, steps + 1):
+        values[:, t] = mean + phi * (values[:, t - 1] - mean) + shocks[:, t - 1]
+    time = np.arange(steps + 1, dtype=int)
+    metadata = {
+        "steps": steps,
+        "phi": phi,
+        "sigma": sigma,
+        "mean": mean,
+        "start": start,
+        "paths": paths,
+        "process": "autoregressive",
+    }
+    return SimulationResult(time=time, values=values, metadata=metadata)
+
+
+def simulate_two_state_markov_chain(
+    params: Dict[str, float], seed: Optional[int] = None
+) -> SimulationResult:
+    """Simulate a two state discrete time Markov chain."""
+
+    steps = int(params["steps"])
+    p00 = float(params["p00"])
+    p11 = float(params["p11"])
+    start_state = int(params["start_state"])
+    paths = int(params["paths"])
+
+    if start_state not in (0, 1):
+        raise ValueError("start_state must be 0 or 1 for a two-state Markov chain")
+
+    transition = np.array([[p00, 1 - p00], [1 - p11, p11]], dtype=float)
+    rng = np.random.default_rng(seed)
+    values = np.empty((paths, steps + 1), dtype=int)
+    values[:, 0] = start_state
+    for t in range(1, steps + 1):
+        prev_states = values[:, t - 1]
+        random_values = rng.random(paths)
+        next_states = np.where(
+            random_values < transition[prev_states, 0], 0, 1
+        )
+        values[:, t] = next_states
+
+    time = np.arange(steps + 1, dtype=int)
+    metadata = {
+        "steps": steps,
+        "p00": p00,
+        "p11": p11,
+        "start_state": start_state,
+        "paths": paths,
+        "process": "two_state_markov_chain",
+    }
+    return SimulationResult(time=time, values=values.astype(float), metadata=metadata)

--- a/stochastic_processes/plotting.py
+++ b/stochastic_processes/plotting.py
@@ -1,0 +1,67 @@
+"""Plotting utilities for stochastic process simulations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import matplotlib.pyplot as plt
+
+from .base import ProcessSpec, SimulationResult
+
+
+def plot_simulation(
+    result: SimulationResult,
+    spec: ProcessSpec,
+    *,
+    output_path: Optional[str] = None,
+    show: bool = True,
+) -> None:
+    """Plot the simulated paths.
+
+    Parameters
+    ----------
+    result:
+        Simulation outcome containing the time grid and sample paths.
+    spec:
+        Metadata for the process used to annotate the plot.
+    output_path:
+        If provided, save the figure to this location.
+    show:
+        Display the figure interactively when ``True`` and ``output_path`` is
+        not provided. ``show`` is ignored when ``output_path`` is specified.
+    """
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    for idx, path in enumerate(result.values):
+        label = "Sample path" if idx == 0 else None
+        ax.plot(result.time, path, alpha=0.75, label=label)
+
+    ax.set_title(spec.name)
+    ax.set_xlabel(spec.time_label)
+    ax.set_ylabel(spec.value_label)
+    ax.grid(True, linestyle="--", alpha=0.4)
+
+    text_lines = [f"Category: {spec.category.capitalize()}"]
+    for key, value in result.metadata.items():
+        if key == "process":
+            continue
+        text_lines.append(f"{key}: {value}")
+    ax.legend(loc="upper left")
+    ax.text(
+        0.02,
+        0.98,
+        "\n".join(text_lines),
+        transform=ax.transAxes,
+        verticalalignment="top",
+        bbox=dict(boxstyle="round", facecolor="white", alpha=0.8),
+    )
+    fig.tight_layout()
+
+    if output_path:
+        path = Path(output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(path)
+    elif show:
+        plt.show()
+    plt.close(fig)

--- a/stochastic_processes/registry.py
+++ b/stochastic_processes/registry.py
@@ -1,0 +1,395 @@
+"""Registry of available stochastic process simulators."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping, Optional
+
+from .base import (
+    ParameterSpec,
+    ProcessSpec,
+    SimulationResult,
+    positive_float,
+    positive_int,
+    probability,
+)
+from . import continuous, discrete
+
+
+PROCESS_REGISTRY: Dict[str, ProcessSpec] = {}
+
+
+def _register(spec: ProcessSpec) -> None:
+    PROCESS_REGISTRY[spec.key] = spec
+
+
+_register(
+    ProcessSpec(
+        key="simple_random_walk",
+        name="Simple Random Walk",
+        category="discrete",
+        description="Biased or unbiased discrete-time random walk with configurable step size.",
+        simulator=discrete.simulate_simple_random_walk,
+        parameters={
+            "steps": ParameterSpec(
+                name="steps",
+                type=int,
+                default=100,
+                help="Number of steps to simulate.",
+                validator=positive_int,
+            ),
+            "start": ParameterSpec(
+                name="start",
+                type=float,
+                default=0.0,
+                help="Starting value of the process.",
+            ),
+            "p": ParameterSpec(
+                name="p",
+                type=float,
+                default=0.5,
+                help="Probability of an upward move at each step.",
+                validator=probability,
+            ),
+            "paths": ParameterSpec(
+                name="paths",
+                type=int,
+                default=5,
+                help="Number of sample paths to simulate.",
+                validator=positive_int,
+            ),
+            "step_size": ParameterSpec(
+                name="step_size",
+                type=float,
+                default=1.0,
+                help="Magnitude of each step.",
+                validator=positive_float,
+            ),
+        },
+        time_label="Step",
+        value_label="Position",
+    )
+)
+
+_register(
+    ProcessSpec(
+        key="autoregressive",
+        name="Autoregressive AR(1)",
+        category="discrete",
+        description="First order autoregressive process with Gaussian innovations.",
+        simulator=discrete.simulate_autoregressive,
+        parameters={
+            "steps": ParameterSpec(
+                name="steps",
+                type=int,
+                default=200,
+                help="Number of steps to simulate.",
+                validator=positive_int,
+            ),
+            "phi": ParameterSpec(
+                name="phi",
+                type=float,
+                default=0.8,
+                help="Autoregressive coefficient.",
+            ),
+            "sigma": ParameterSpec(
+                name="sigma",
+                type=float,
+                default=0.5,
+                help="Standard deviation of the innovations.",
+                validator=positive_float,
+            ),
+            "mean": ParameterSpec(
+                name="mean",
+                type=float,
+                default=0.0,
+                help="Long-run mean of the process.",
+            ),
+            "start": ParameterSpec(
+                name="start",
+                type=float,
+                default=0.0,
+                help="Initial value of the process.",
+            ),
+            "paths": ParameterSpec(
+                name="paths",
+                type=int,
+                default=3,
+                help="Number of sample paths to simulate.",
+                validator=positive_int,
+            ),
+        },
+        time_label="Step",
+        value_label="Value",
+    )
+)
+
+_register(
+    ProcessSpec(
+        key="two_state_markov_chain",
+        name="Two-State Markov Chain",
+        category="discrete",
+        description="Discrete time Markov chain with two states and configurable transition probabilities.",
+        simulator=discrete.simulate_two_state_markov_chain,
+        parameters={
+            "steps": ParameterSpec(
+                name="steps",
+                type=int,
+                default=100,
+                help="Number of steps to simulate.",
+                validator=positive_int,
+            ),
+            "p00": ParameterSpec(
+                name="p00",
+                type=float,
+                default=0.9,
+                help="Probability of remaining in state 0.",
+                validator=probability,
+            ),
+            "p11": ParameterSpec(
+                name="p11",
+                type=float,
+                default=0.8,
+                help="Probability of remaining in state 1.",
+                validator=probability,
+            ),
+            "start_state": ParameterSpec(
+                name="start_state",
+                type=int,
+                default=0,
+                help="Initial state (0 or 1).",
+                choices=[0, 1],
+            ),
+            "paths": ParameterSpec(
+                name="paths",
+                type=int,
+                default=5,
+                help="Number of sample paths to simulate.",
+                validator=positive_int,
+            ),
+        },
+        time_label="Step",
+        value_label="State",
+    )
+)
+
+_register(
+    ProcessSpec(
+        key="poisson_process",
+        name="Poisson Process",
+        category="continuous",
+        description="Counting process with exponentially distributed inter-arrival times.",
+        simulator=continuous.simulate_poisson_process,
+        parameters={
+            "rate": ParameterSpec(
+                name="rate",
+                type=float,
+                default=2.0,
+                help="Average number of events per unit time.",
+                validator=positive_float,
+            ),
+            "t_max": ParameterSpec(
+                name="t_max",
+                type=float,
+                default=10.0,
+                help="Total simulation time horizon.",
+                validator=positive_float,
+            ),
+            "dt": ParameterSpec(
+                name="dt",
+                type=float,
+                default=0.1,
+                help="Time discretisation step used for sampling.",
+                validator=positive_float,
+            ),
+            "paths": ParameterSpec(
+                name="paths",
+                type=int,
+                default=5,
+                help="Number of sample paths to simulate.",
+                validator=positive_int,
+            ),
+        },
+        time_label="Time",
+        value_label="Count",
+    )
+)
+
+_register(
+    ProcessSpec(
+        key="brownian_motion",
+        name="Brownian Motion",
+        category="continuous",
+        description="Brownian motion with drift and volatility parameters.",
+        simulator=continuous.simulate_brownian_motion,
+        parameters={
+            "drift": ParameterSpec(
+                name="drift",
+                type=float,
+                default=0.0,
+                help="Drift component of the process.",
+            ),
+            "volatility": ParameterSpec(
+                name="volatility",
+                type=float,
+                default=1.0,
+                help="Volatility (diffusion coefficient).",
+                validator=positive_float,
+            ),
+            "t_max": ParameterSpec(
+                name="t_max",
+                type=float,
+                default=1.0,
+                help="Total simulation time horizon.",
+                validator=positive_float,
+            ),
+            "dt": ParameterSpec(
+                name="dt",
+                type=float,
+                default=0.01,
+                help="Time discretisation step used for sampling.",
+                validator=positive_float,
+            ),
+            "paths": ParameterSpec(
+                name="paths",
+                type=int,
+                default=5,
+                help="Number of sample paths to simulate.",
+                validator=positive_int,
+            ),
+        },
+        time_label="Time",
+        value_label="Value",
+    )
+)
+
+_register(
+    ProcessSpec(
+        key="geometric_brownian_motion",
+        name="Geometric Brownian Motion",
+        category="continuous",
+        description="Geometric Brownian motion often used for modelling stock prices.",
+        simulator=continuous.simulate_geometric_brownian_motion,
+        parameters={
+            "mu": ParameterSpec(
+                name="mu",
+                type=float,
+                default=0.1,
+                help="Drift of the log returns.",
+            ),
+            "sigma": ParameterSpec(
+                name="sigma",
+                type=float,
+                default=0.2,
+                help="Volatility of the process.",
+                validator=positive_float,
+            ),
+            "initial": ParameterSpec(
+                name="initial",
+                type=float,
+                default=1.0,
+                help="Initial level of the process.",
+                validator=positive_float,
+            ),
+            "t_max": ParameterSpec(
+                name="t_max",
+                type=float,
+                default=1.0,
+                help="Total simulation time horizon.",
+                validator=positive_float,
+            ),
+            "dt": ParameterSpec(
+                name="dt",
+                type=float,
+                default=0.01,
+                help="Time discretisation step used for sampling.",
+                validator=positive_float,
+            ),
+            "paths": ParameterSpec(
+                name="paths",
+                type=int,
+                default=5,
+                help="Number of sample paths to simulate.",
+                validator=positive_int,
+            ),
+        },
+        time_label="Time",
+        value_label="Value",
+    )
+)
+
+_register(
+    ProcessSpec(
+        key="ornstein_uhlenbeck",
+        name="Ornstein-Uhlenbeck",
+        category="continuous",
+        description="Mean-reverting diffusion process.",
+        simulator=continuous.simulate_ornstein_uhlenbeck,
+        parameters={
+            "theta": ParameterSpec(
+                name="theta",
+                type=float,
+                default=1.0,
+                help="Speed of mean reversion.",
+                validator=positive_float,
+            ),
+            "mu": ParameterSpec(
+                name="mu",
+                type=float,
+                default=0.0,
+                help="Long-run mean level.",
+            ),
+            "sigma": ParameterSpec(
+                name="sigma",
+                type=float,
+                default=0.3,
+                help="Volatility parameter.",
+                validator=positive_float,
+            ),
+            "initial": ParameterSpec(
+                name="initial",
+                type=float,
+                default=0.0,
+                help="Initial level of the process.",
+            ),
+            "t_max": ParameterSpec(
+                name="t_max",
+                type=float,
+                default=1.0,
+                help="Total simulation time horizon.",
+                validator=positive_float,
+            ),
+            "dt": ParameterSpec(
+                name="dt",
+                type=float,
+                default=0.01,
+                help="Time discretisation step used for sampling.",
+                validator=positive_float,
+            ),
+            "paths": ParameterSpec(
+                name="paths",
+                type=int,
+                default=5,
+                help="Number of sample paths to simulate.",
+                validator=positive_int,
+            ),
+        },
+        time_label="Time",
+        value_label="Value",
+    )
+)
+
+
+def get_process_spec(key: str) -> ProcessSpec:
+    return PROCESS_REGISTRY[key]
+
+
+def list_processes() -> Iterable[ProcessSpec]:
+    return PROCESS_REGISTRY.values()
+
+
+def simulate_process(
+    key: str, overrides: Optional[Mapping[str, object]] = None, seed: Optional[int] = None
+) -> SimulationResult:
+    spec = get_process_spec(key)
+    params = spec.coerce_parameters(overrides)
+    return spec.simulator(params, seed)

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+from stochastic_processes import get_process_spec, simulate_process
+
+
+def test_random_walk_returns_expected_shape():
+    result = simulate_process(
+        "simple_random_walk",
+        overrides={"steps": 50, "paths": 2, "start": 1.0, "p": 0.6},
+        seed=42,
+    )
+    assert result.values.shape == (2, 51)
+    np.testing.assert_allclose(result.values[:, 0], 1.0)
+
+
+def test_poisson_process_is_non_decreasing():
+    result = simulate_process(
+        "poisson_process",
+        overrides={"rate": 5.0, "t_max": 2.0, "dt": 0.1, "paths": 3},
+        seed=123,
+    )
+    diffs = np.diff(result.values, axis=1)
+    assert np.all(diffs >= 0)
+
+
+def test_geometric_brownian_motion_positive():
+    result = simulate_process(
+        "geometric_brownian_motion",
+        overrides={"mu": 0.05, "sigma": 0.1, "initial": 2.0, "paths": 4},
+        seed=99,
+    )
+    assert np.all(result.values > 0)
+
+
+def test_default_parameters_are_accessible():
+    spec = get_process_spec("ornstein_uhlenbeck")
+    params = spec.coerce_parameters()
+    assert params["theta"] == spec.parameters["theta"].default
+    assert params["paths"] == spec.parameters["paths"].default


### PR DESCRIPTION
## Summary
- add a Python package with simulators for common discrete and continuous time processes
- implement a CLI that runs simulations, lets the user override parameters, and renders matplotlib plots
- document usage instructions, dependencies, and add regression tests for core simulations

## Testing
- `pip install -r requirements.txt` *(fails: network access to fetch matplotlib is blocked)*
- `pytest` *(fails: numpy is not available because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd2b0c138832287263d5055106988